### PR TITLE
Fix for vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "type": "git",
     "url": "git://github.com/mercmobily/hotplate.git"
   },
-
   "dependencies": {
     "eventemittercollector": "0.3.x",
     "allhttperrors": "0.3.x",
@@ -30,7 +29,7 @@
     "twilio": "~2.9.0",
     "nodemailer": "~2.3.0",
     "imap": "~0.8.14",
-    "request": "~2.69.0",
+    "request": "~2.74.0",
     "sanitize-caja": "~0.1.2",
     "html-to-text": "~2.0.0",
     "mimelib": "~0.2.19",


### PR DESCRIPTION
hotplate currently has a 1 vulnerable dependency paths, introducing 1 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.

You can see [Snyk test report](https://snyk.io/test/github/mercmobily/hotplate) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Team
